### PR TITLE
Add removeTransaction implementation with test coverage

### DIFF
--- a/Personal-Finance-Tracker/src/main/kotlin/datasource/InMemoryTransactionDataSourceImpl.kt
+++ b/Personal-Finance-Tracker/src/main/kotlin/datasource/InMemoryTransactionDataSourceImpl.kt
@@ -4,14 +4,15 @@ import datasource.TransactionDataSource
 import models.Transaction
 import java.time.LocalDateTime
 
-class InMemoryTransactionDataSourceImpl:TransactionDataSource {
+class InMemoryTransactionDataSourceImpl : TransactionDataSource {
+    val transactionList = mutableListOf<Transaction>()
+
     override fun createTransaction(transaction: Transaction) {
         TODO("Not yet implemented")
     }
 
-    override fun removeTransaction(transaction: Transaction) {
-        TODO("Not yet implemented")
-    }
+    override fun removeTransaction(transaction: Transaction) =
+        transactionList.removeIf { it.id == transaction.id }
 
     override fun updateTransaction(transaction: Transaction) {
         TODO("Not yet implemented")

--- a/Personal-Finance-Tracker/src/main/kotlin/datasource/TransactionDataSource.kt
+++ b/Personal-Finance-Tracker/src/main/kotlin/datasource/TransactionDataSource.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 
 interface TransactionDataSource {
     fun createTransaction(transaction: Transaction)
-    fun removeTransaction(transaction: Transaction)
+    fun removeTransaction(transaction: Transaction): Boolean
     fun updateTransaction(transaction: Transaction)
     fun getAllTransaction(): List<Transaction>
     fun getTransactionByDate(date: LocalDateTime): List<Transaction>

--- a/Personal-Finance-Tracker/src/main/kotlin/test/TransactionRemoveTest.kt
+++ b/Personal-Finance-Tracker/src/main/kotlin/test/TransactionRemoveTest.kt
@@ -1,0 +1,33 @@
+package org.example.test
+
+fun main(){
+
+    check(
+        name = "When removing from empty list, then should return false",
+        result=false,
+        expected =  false
+    )
+    check(
+        name = "When removing existing transaction, then should return true",
+        result = true,
+        expected = true
+    )
+    check(
+        name = "When removing same data but different ID, then should return false",
+        result =  false ,
+        expected =  false
+    )
+    check(
+        name = "When removing one of multiple transactions, then should return true",
+        result= true,
+        expected = true
+    )
+}
+
+fun <T>check(name: String, result: T, expected: T) {
+    if (result == expected) {
+        println("Successful: $name")
+    } else {
+        println("X-Failed: $name | Expected: $expected, Got: $result")
+    }
+}

--- a/Personal-Finance-Tracker/src/main/kotlin/test/TransactionRemoveTest.kt
+++ b/Personal-Finance-Tracker/src/main/kotlin/test/TransactionRemoveTest.kt
@@ -1,33 +1,61 @@
 package org.example.test
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import models.Category
+import models.Transaction
+import org.example.common.check
+import org.example.datasource.FakeTransactionDataSourceImpl
 
 fun main(){
+    val dataSource = FakeTransactionDataSourceImpl()
+
+    val validWithdrawalTransaction = Transaction(
+        name = "Withdrawal Transaction",
+        isDeposit = false,
+        amount = 150.0,
+        category = Category.RENT,
+        creationDate = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date,
+        editDate = emptyList()
+    )
+
+    val validDepositTransaction = Transaction(
+        name = "Deposit Transaction",
+        isDeposit = true,
+        amount = 150.0,
+        category = Category.RENT,
+        creationDate = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date,
+        editDate = emptyList()
+    )
+    val validDepositTransaction2 = Transaction(
+        name = "Deposit Transaction",
+        isDeposit = true,
+        amount = 150.0,
+        category = Category.RENT,
+        creationDate = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date,
+        editDate = emptyList()
+    )
 
     check(
         name = "When removing from empty list, then should return false",
-        result=false,
+        actual=dataSource.removeTransaction(validWithdrawalTransaction),
         expected =  false
     )
     check(
         name = "When removing existing transaction, then should return true",
-        result = true,
+        actual = dataSource.removeTransaction(validDepositTransaction),
         expected = true
     )
     check(
         name = "When removing same data but different ID, then should return false",
-        result =  false ,
+        actual =  dataSource.removeTransaction(validDepositTransaction) ,
         expected =  false
     )
     check(
         name = "When removing one of multiple transactions, then should return true",
-        result= true,
+        actual= dataSource.removeTransaction(validDepositTransaction2),
         expected = true
     )
+
 }
 
-fun <T>check(name: String, result: T, expected: T) {
-    if (result == expected) {
-        println("Successful: $name")
-    } else {
-        println("X-Failed: $name | Expected: $expected, Got: $result")
-    }
-}


### PR DESCRIPTION
**Implement and test removeTransaction functionality**

1.  Added implementation for removeTransaction in InMemoryTransactionDataSourceImpl
2.  Created TransactionRemoveTest.kt to validate different test cases for transaction removal
3.  Ensured edge cases are handled: non-existent transaction, empty list, etc.
4.   Used 'check' function for readable test output using "when...then..." format