### PR TITLE
Add transactions using createTransaction before removal, improve tests

### DIFF
--- a/Personal-Finance-Tracker/src/main/kotlin/test/TransactionRemoveTest.kt
+++ b/Personal-Finance-Tracker/src/main/kotlin/test/TransactionRemoveTest.kt
@@ -6,6 +6,7 @@ import models.Category
 import models.Transaction
 import org.example.common.check
 import org.example.datasource.FakeTransactionDataSourceImpl
+import java.util.UUID
 
 fun main(){
     val dataSource = FakeTransactionDataSourceImpl()
@@ -35,27 +36,30 @@ fun main(){
         creationDate = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date,
         editDate = emptyList()
     )
-
     check(
         name = "When removing from empty list, then should return false",
         actual=dataSource.removeTransaction(validWithdrawalTransaction),
         expected =  false
     )
+
+    dataSource.createTransaction(transaction = validDepositTransaction)
     check(
         name = "When removing existing transaction, then should return true",
         actual = dataSource.removeTransaction(validDepositTransaction),
         expected = true
     )
+    val fakeTransaction = validDepositTransaction.copy(id = UUID.randomUUID())
     check(
         name = "When removing same data but different ID, then should return false",
-        actual =  dataSource.removeTransaction(validDepositTransaction) ,
+        actual =  dataSource.removeTransaction(fakeTransaction) ,
         expected =  false
     )
+    dataSource.createTransaction(transaction = validDepositTransaction)
+    dataSource.createTransaction(transaction = validDepositTransaction2)
     check(
         name = "When removing one of multiple transactions, then should return true",
         actual= dataSource.removeTransaction(validDepositTransaction2),
         expected = true
     )
-
 }
 


### PR DESCRIPTION
- Ensure transactions are added using createTransaction before attempting removal.
- Added test case to verify removal of transactions with different UUIDs (identity check).
- Updated tests to reflect correct behavior when removing from empty list, removing existing transactions, and removing from a list with multiple transactions.
